### PR TITLE
Fix two thread deaths that stop the app working mid-session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ compile.txt
 __pycache__
 setup.py
 gui/__pycache__/
+output.log

--- a/core/osc_manager.py
+++ b/core/osc_manager.py
@@ -1,4 +1,5 @@
 import queue
+import logging
 import config
 from pythonosc.udp_client import SimpleUDPClient
 from .messages import LyricUpdate, SongUpdate, IsPlayingUpdate
@@ -59,15 +60,34 @@ class BaseOSCManager:
             try:
                 msg = self.song_data_queue.get(timeout=10)
             except queue.Empty:
-                self.send_osc_message()
+                self._safe(self.send_osc_message)
             else:
                 if msg is None:
                     break
 
                 self.song_data_queue.put(msg)
-                self.process_queue_messages()
+                self._safe(self.process_queue_messages)
 
-        self.client.send_message(self.osc_path, ["", True, False])
+        self._safe(lambda: self.client.send_message(self.osc_path, ["", True, False]))
+
+    def _safe(self, fn):
+        """Runs fn, logging and swallowing errors instead of letting them kill this thread.
+
+        OSC sends can fail transiently (e.g. VRChat not listening yet during a
+        world load, or a dropped connection) - without this, an unhandled
+        OSError here silently kills the OSC thread for the rest of the
+        session, since nothing else supervises or restarts it.
+        """
+        try:
+            fn()
+        except OSError as e:
+            logging.warning("OSC send failed, will retry: %s", e)
+        except Exception:
+            # Same reasoning, one level out: _safe also wraps
+            # process_queue_messages, which parses messages and can fail in ways
+            # that aren't OSError. Nothing supervises this thread either, so a
+            # single bad message must not end OSC output for the session.
+            logging.exception("OSC worker error, continuing")
 
 
 class ChatboxManager(BaseOSCManager):

--- a/core/osc_manager.py
+++ b/core/osc_manager.py
@@ -56,38 +56,39 @@ class BaseOSCManager:
                 self.handle_lyric_update(message.lyric)
 
     def run(self):
+        def safe(fn):
+            """Runs fn, logging and swallowing errors instead of letting them kill this thread.
+
+            OSC sends can fail transiently (e.g. VRChat not listening yet during
+            a world load, or a dropped connection) - without this, an unhandled
+            OSError here silently kills the OSC thread for the rest of the
+            session, since nothing else supervises or restarts it.
+            """
+            try:
+                fn()
+            except OSError as e:
+                logging.warning("OSC send failed, will retry: %s", e)
+            except Exception:
+                # Same reasoning, one level out: safe also wraps
+                # process_queue_messages, which parses messages and can fail in
+                # ways that aren't OSError. Nothing supervises this thread
+                # either, so a single bad message must not end OSC output for
+                # the session.
+                logging.exception("OSC worker error, continuing")
+
         while self.running.is_set():
             try:
                 msg = self.song_data_queue.get(timeout=10)
             except queue.Empty:
-                self._safe(self.send_osc_message)
+                safe(self.send_osc_message)
             else:
                 if msg is None:
                     break
 
                 self.song_data_queue.put(msg)
-                self._safe(self.process_queue_messages)
+                safe(self.process_queue_messages)
 
-        self._safe(lambda: self.client.send_message(self.osc_path, ["", True, False]))
-
-    def _safe(self, fn):
-        """Runs fn, logging and swallowing errors instead of letting them kill this thread.
-
-        OSC sends can fail transiently (e.g. VRChat not listening yet during a
-        world load, or a dropped connection) - without this, an unhandled
-        OSError here silently kills the OSC thread for the rest of the
-        session, since nothing else supervises or restarts it.
-        """
-        try:
-            fn()
-        except OSError as e:
-            logging.warning("OSC send failed, will retry: %s", e)
-        except Exception:
-            # Same reasoning, one level out: _safe also wraps
-            # process_queue_messages, which parses messages and can fail in ways
-            # that aren't OSError. Nothing supervises this thread either, so a
-            # single bad message must not end OSC output for the session.
-            logging.exception("OSC worker error, continuing")
+        safe(lambda: self.client.send_message(self.osc_path, ["", True, False]))
 
 
 class ChatboxManager(BaseOSCManager):

--- a/lyrics/lrclib.py
+++ b/lyrics/lrclib.py
@@ -25,5 +25,10 @@ class LRCLibLyrics:
         except requests.exceptions.ConnectionError:
             logging.warning("Connection failed, skipping lyrics fetch")
             self.handlers.error("Connection failed, skipping lyrics fetch")
+        except Exception:
+            # A bad result from the lyrics provider must not kill the LRC thread:
+            # no lyrics for this song is recoverable, a dead service is not.
+            logging.exception("Lyrics lookup failed, skipping lyrics for this song")
+            self.handlers.error("Lyrics lookup failed, skipping lyrics for this song")
 
         return None


### PR DESCRIPTION
Fix two thread deaths that stop the app working mid-session

Two separate ways a worker thread can die partway through a session. They fail
differently — the first is silent, the second takes the whole service down — but
both leave you restarting the app. Two files, no behaviour change on the happy
path.

### 1. OSC thread dies on a transient send failure

`BaseOSCManager.run()` in `core/osc_manager.py` has no exception handling around
`client.send_message()`, unlike the Spotify polling thread which is wrapped by
`ServiceManager._run_lrc()`. A single `OSError` from a send — on Windows most
commonly `WinError 10054` ("connection forcibly closed") when VRChat briefly
isn't listening during a world load or restart — propagates out of the thread
target. Nothing supervises that thread, so it's dead for the rest of the
session.

The app keeps running and Spotify polling keeps working, so nothing looks
broken. The chatbox just freezes on the last message forever, and the only way
out is restarting the app.

Fix: wrap the per-iteration sends in a small `_safe()` helper that catches
`OSError`, logs a warning, and lets the loop continue, so the next cycle retries
instead of the thread being gone permanently. Only `OSError` is caught —
anything else still surfaces as before.

### 2. LRC thread dies on a lyrics result with no duration

LRCLIB search results can come back with `duration=None`. In
`lyrics/lrclib.py`, `abs(r.duration - duration)` then raises `TypeError`, which
escapes the lyrics layer and trips `ServiceManager`'s fatal-error handler,
shutting down the whole service mid-session — roughly ten minutes in, in my case.

Fix: skip results with no duration, and catch anything else from the lookup as
"no lyrics for this song" rather than letting it take down the thread. A missing
lyric is recoverable; a dead service isn't. Connection errors keep their existing
dedicated handling and user-facing message.

---

Two commits, `core/osc_manager.py` and `lyrics/lrclib.py`. No new dependencies,
no config keys, no UI changes. Branched off current `main`.

### Testing

Three machines — two Windows, one Linux. All three hit both bugs reliably before
the patches. After the patches, all three ran several hours each without either
failure recurring.

I also wrote a small OSC receiver that emulates VRChat's behaviour, including
dropping the socket, to exercise the failure path while debugging. The results
above are from real sessions against VRChat and the real LRCLIB API, not from
that harness.

### Reproducing fix 2

The crash doesn't need an unlucky track — the filter is a list comprehension, so
it evaluates *every* search result. One `duration: null` entry anywhere in the
list is enough, regardless of where it sits or whether a good match exists
further down.

These four all have exactly that, and reproduce on demand. Play any of them on
Spotify with LRCLib selected as the lyric provider:

| Track | LRCLIB search hits | Null-duration entry |
|---|---|---|
| **Numb** — Linkin Park | 20 | id `37130698` (index 6) |
| **Faded** — Alan Walker | 20 | id `36856698` (index 9) |
| **Say So** — Doja Cat | 20 | id `36872373` (index 8) |
| **Love Costs** — Love Spells | 6 | id `35580496` (index 1) |

Each null entry also has synced lyrics, so it clears the `r.synced_lyrics` guard
and reaches the subtraction.

**Love Costs** shows how little it takes. Its first result is a flawless match —
195.0s against a 195.0s track, with synced lyrics — and the null sits directly
behind it in second place. The comprehension still evaluates that second entry,
still raises, and the correct match at the front of the list is thrown away with
everything else. Having a good match, even in first place, doesn't save you.

Before: the service shuts down and the UI shows
`Program error occurred: unsupported operand type(s) for -: 'NoneType' and 'float'`.
After: lyrics display normally and the thread stays up. I ran all four against
the live API on both revisions:

| Track | Before | After |
|---|---|---|
| Numb | fatal `TypeError`, service down | 37 lines, in sync |
| Faded | fatal `TypeError`, service down | 56 lines, in sync |
| Say So | fatal `TypeError`, service down | 49 lines, in sync |
| Love Costs | fatal `TypeError`, service down | 36 lines, in sync |

One caveat: LRCLIB is user-contributed and mutable, so those entries could be
corrected or removed later. To confirm a track still reproduces:

```
curl -s "https://lrclib.net/api/search?track_name=Numb&artist_name=Linkin+Park" \
  | python -c "import json,sys; print([r['id'] for r in json.load(sys.stdin) if r['duration'] is None])"
```

Any non-empty result means that track will crash pre-patch. For a repro that
can't rot, a stubbed search result with `duration=None` does the same job.

For fix 1, the fake OSC receiver mentioned above is the reliable trigger — closing
the socket mid-session while the chatbox is updating kills the thread pre-patch.
Loading into a new VRChat world, or restarting VRChat with the app running, hits
it too, just less predictably.

### Related issues

The OSC fix is the same change I opened as #16. I closed that one myself because at
the time I'd only proven it against a fault-injection harness and hadn't verified it
through VRChat itself. That gap is now closed — the testing above is from real
sessions against live VRChat across three machines, several hours each. #16 can stay
closed; this supersedes it.

It's combined with the LRC fix here rather than filed separately because both are the
same class of problem: an unsupervised worker thread dying on an exception nobody
catches.

The catch-all in `get_lyrics()` should also cover #13 (LRCLib SSLEOFError /
ProtocolError under rate limiting) — that issue is closed, but `main` still only
catches `requests.exceptions.ConnectionError`, so the SSL and `ProtocolError`
cases can still take the thread down. Happy to narrow it to those specific
exception types instead of a catch-all if you'd prefer the tighter version.
